### PR TITLE
Fix deprecated pipelines

### DIFF
--- a/.woodpecker/build.yml
+++ b/.woodpecker/build.yml
@@ -9,14 +9,18 @@ steps:
       - make vet
       - make formatcheck
     when:
-      event: pull_request
+      - event: pull_request
+      - event: push
+        branch: renovate/*
 
   test:
     image: *golang
     commands:
       - make test
     when:
-      event: pull_request
+      - event: pull_request
+      - event: push
+        branch: renovate/*
 
   build-dryrun:
     image: *docker_buildx
@@ -28,7 +32,9 @@ steps:
       platforms: linux/arm/v7,linux/arm64/v8,linux/amd64,linux/ppc64le
       tags: test
     when:
-      event: pull_request
+      - event: pull_request
+      - event: push
+        branch: renovate/*
 
   build-next:
     image: *docker_buildx


### PR DESCRIPTION
- replace `group`
- add event filters
- remove useless `version` step (it just `echo`s the version)
- only run test/lint on PRs and renovate branches